### PR TITLE
Remove legacy fix & StringW moment

### DIFF
--- a/.github/workflows/build-ndk.yml
+++ b/.github/workflows/build-ndk.yml
@@ -78,10 +78,6 @@ jobs:
         ls -la ${GITHUB_WORKSPACE}/extern/libs
         echo cache:
         ls -la $HOME/.local/share/QPM-Rust/cache
-        
-    - name: Apply Legacy Fix
-      run: |
-        ./QPM/qpm-rust cache legacy-fix
 
     - name: Build
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,10 +67,6 @@ jobs:
         ls -la ${GITHUB_WORKSPACE}/extern/libs
         echo cache:
         ls -la $HOME/.local/share/QPM-Rust/cache
-    
-    - name: Apply Legacy Fix
-      run: |
-        ./QPM/qpm-rust cache legacy-fix
 
     - name: Get Tag Version
       id: get_tag_version

--- a/mod.template.json
+++ b/mod.template.json
@@ -1,5 +1,5 @@
 {
-  "_QPVersion": "0.1.2",
+  "_QPVersion": "0.1.1",
   "name": "${mod_name}",
   "id": "${mod_id}",
   "author": "darknight1050",

--- a/shared/CustomTypes/SongLoaderCustomBeatmapLevelPack.hpp
+++ b/shared/CustomTypes/SongLoaderCustomBeatmapLevelPack.hpp
@@ -14,10 +14,10 @@ DECLARE_CLASS_CODEGEN(RuntimeSongLoader, SongLoaderCustomBeatmapLevelPack, Il2Cp
     DECLARE_INSTANCE_FIELD(GlobalNamespace::CustomBeatmapLevelCollection*, CustomLevelsCollection);
     DECLARE_INSTANCE_FIELD(GlobalNamespace::CustomBeatmapLevelPack*, CustomLevelsPack);
 
-    DECLARE_CTOR(ctor, Il2CppString* packID, Il2CppString* packName, UnityEngine::Sprite* coverImage);
+    DECLARE_CTOR(ctor, StringW packID, StringW packName, UnityEngine::Sprite* coverImage = nullptr);
 
     public:
-        static SongLoaderCustomBeatmapLevelPack* New_ctor(std::string const& packID, std::string_view packName, UnityEngine::Sprite* coverImage = nullptr);
+        static SongLoaderCustomBeatmapLevelPack* Make_New(std::string const& packID, std::string_view packName, UnityEngine::Sprite* coverImage = nullptr);
 
         ArrayW<GlobalNamespace::CustomPreviewBeatmapLevel*> GetCustomPreviewBeatmapLevels();
         void SetCustomPreviewBeatmapLevels(ArrayW<GlobalNamespace::CustomPreviewBeatmapLevel*> customPreviewBeatmapLevels);

--- a/src/CustomBeatmapLevelLoader.cpp
+++ b/src/CustomBeatmapLevelLoader.cpp
@@ -158,8 +158,8 @@ namespace RuntimeSongLoader::CustomBeatmapLevelLoader {
         return customBeatmapLevel;
     }
 
-    MAKE_HOOK_MATCH(BeatmapLevelsModel_GetBeatmapLevelAsync, &BeatmapLevelsModel::GetBeatmapLevelAsync, Task_1<BeatmapLevelsModel::GetBeatmapLevelResult>*, BeatmapLevelsModel* self, Il2CppString* levelID, CancellationToken cancellationToken) {
-        LOG_INFO("BeatmapLevelsModel_GetBeatmapLevelAsync Start %s", to_utf8(csstrtostr(levelID)).c_str());
+    MAKE_HOOK_MATCH(BeatmapLevelsModel_GetBeatmapLevelAsync, &BeatmapLevelsModel::GetBeatmapLevelAsync, Task_1<BeatmapLevelsModel::GetBeatmapLevelResult>*, BeatmapLevelsModel* self, StringW levelID, CancellationToken cancellationToken) {
+        LOG_INFO("BeatmapLevelsModel_GetBeatmapLevelAsync Start %s", levelID.operator std::string().c_str());
         Task_1<BeatmapLevelsModel::GetBeatmapLevelResult>* result = BeatmapLevelsModel_GetBeatmapLevelAsync(self, levelID, cancellationToken);
         if(result->get_IsCompleted() && result->get_Result().isError) {
             if(self->loadedPreviewBeatmapLevels->ContainsKey(levelID)) {

--- a/src/CustomCharacteristics.cpp
+++ b/src/CustomCharacteristics.cpp
@@ -78,7 +78,7 @@ namespace RuntimeSongLoader::CustomCharacteristics {
         return nullptr;
     }  
 
-    MAKE_HOOK_MATCH(BeatmapCharacteristicCollectionSO_GetBeatmapCharacteristicBySerializedName,&BeatmapCharacteristicCollectionSO::GetBeatmapCharacteristicBySerializedName, BeatmapCharacteristicSO*, BeatmapCharacteristicCollectionSO* self, Il2CppString* serializedName)
+    MAKE_HOOK_MATCH(BeatmapCharacteristicCollectionSO_GetBeatmapCharacteristicBySerializedName,&BeatmapCharacteristicCollectionSO::GetBeatmapCharacteristicBySerializedName, BeatmapCharacteristicSO*, BeatmapCharacteristicCollectionSO* self, StringW serializedName)
     {
         BeatmapCharacteristicSO* result = BeatmapCharacteristicCollectionSO_GetBeatmapCharacteristicBySerializedName(self, serializedName);
         if(!result)

--- a/src/CustomTypes/SongLoader.cpp
+++ b/src/CustomTypes/SongLoader.cpp
@@ -114,8 +114,8 @@ void SongLoader::ctor() {
     CustomLevels = Dictionary_2<Il2CppString*, CustomPreviewBeatmapLevel*>::New_ctor();
     CustomWIPLevels = Dictionary_2<Il2CppString*, CustomPreviewBeatmapLevel*>::New_ctor();
 
-    CustomLevelsPack = SongLoaderCustomBeatmapLevelPack::New_ctor(CustomLevelsFolder, "Custom Levels");
-    CustomWIPLevelsPack = SongLoaderCustomBeatmapLevelPack::New_ctor(CustomWIPLevelsFolder, "WIP Levels", QuestUI::BeatSaberUI::Base64ToSprite(Sprites::CustomWIPLevelsCover));
+    CustomLevelsPack = SongLoaderCustomBeatmapLevelPack::Make_New(CustomLevelsFolder, "Custom Levels");
+    CustomWIPLevelsPack = SongLoaderCustomBeatmapLevelPack::Make_New(CustomWIPLevelsFolder, "WIP Levels", QuestUI::BeatSaberUI::Base64ToSprite(Sprites::CustomWIPLevelsCover));
     CustomBeatmapLevelPackCollectionSO = RuntimeSongLoader::SongLoaderBeatmapLevelPackCollectionSO::CreateNew();
 }
 

--- a/src/CustomTypes/SongLoaderCustomBeatmapLevelPack.cpp
+++ b/src/CustomTypes/SongLoaderCustomBeatmapLevelPack.cpp
@@ -11,13 +11,14 @@ using namespace UnityEngine;
 
 DEFINE_TYPE(RuntimeSongLoader, SongLoaderCustomBeatmapLevelPack);
 
-SongLoaderCustomBeatmapLevelPack* SongLoaderCustomBeatmapLevelPack::New_ctor(std::string const& packID, std::string_view packName, Sprite* coverImage) {
+
+SongLoaderCustomBeatmapLevelPack* SongLoaderCustomBeatmapLevelPack::Make_New(std::string const& packID, std::string_view packName, Sprite* coverImage) {
     auto customLevelsPackID = il2cpp_utils::newcsstr(CustomLevelPackPrefixID + packID);
     auto customLevelsPackName = il2cpp_utils::newcsstr(packName);
     return *il2cpp_utils::New<SongLoaderCustomBeatmapLevelPack*>(customLevelsPackID, customLevelsPackName, coverImage);
 }
 
-void SongLoaderCustomBeatmapLevelPack::ctor(Il2CppString* packID, Il2CppString* packName, Sprite* coverImage) {
+void SongLoaderCustomBeatmapLevelPack::ctor(StringW packID, StringW packName, Sprite* coverImage) {
     CustomLevelsCollection = CustomBeatmapLevelCollection::New_ctor(ArrayW<CustomPreviewBeatmapLevel*>());
     auto newCoverImage = coverImage ? coverImage : FindComponentsUtils::GetCustomLevelLoader()->defaultPackCover;
     CustomLevelsPack = CustomBeatmapLevelPack::New_ctor(packID, packName, packName, newCoverImage, newCoverImage, CustomLevelsCollection);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -205,7 +205,7 @@ MAKE_HOOK_MATCH(StandardLevelDetailView_RefreshContent,
 
 MAKE_HOOK_MATCH(StandardLevelDetailViewController_ShowContent,
                 &StandardLevelDetailViewController::ShowContent,
-                void, StandardLevelDetailViewController* self, StandardLevelDetailViewController::ContentType contentType, Il2CppString* errorText, float downloadingProgress, Il2CppString* downloadingText) {
+                void, StandardLevelDetailViewController* self, StandardLevelDetailViewController::ContentType contentType, StringW errorText, float downloadingProgress, StringW downloadingText) {
     StandardLevelDetailViewController_ShowContent(self, contentType, errorText, downloadingProgress, downloadingText);
     static Il2CppClass* customPreviewBeatmapLevelClass = classof(CustomPreviewBeatmapLevel*);
     bool customLevel = self->previewBeatmapLevel && il2cpp_functions::class_is_assignable_from(customPreviewBeatmapLevelClass, il2cpp_functions::object_get_class(reinterpret_cast<Il2CppObject*>(self->previewBeatmapLevel)));


### PR DESCRIPTION
 - Remove using the legacy fix in actions since that's no longer needed
 - Fix a bunch of occurences of broken make hooks because they were still using Il2CppString* instead of the new StringW
 - Renamed the `SongLoaderCustomBeatmapLevelPack::New_ctor` to `SongLoaderCustomBeatmapLevelPack::Make_New` due to issues caused by new custom types