### PR TITLE
Install a hook onto transition to attempt to fix liveness

### DIFF
--- a/include/CustomLogger.hpp
+++ b/include/CustomLogger.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#define STRINGIFY(val) #val
+#define STRINGIFY1(val) STRINGIFY(val)
+#define EXPAND_FILE __FILE__ ":" STRINGIFY1(__LINE__)
+
 //#define LOG_INFO(...)
 #define LOG_INFO(...) getLogger().info(__VA_ARGS__) 
 #define LOG_DEBUG(...) 


### PR DESCRIPTION
This is because doing things during scene activation callback is actually too early and a GC collection pass will be happening at the same time as song reloads for users with many songs (scheduler dependent).

Essentially, what was taking place was that the scene transition call to spawn a bunch of HMTasks and kick them off was happening at the same time as a `GC::Collect` call, which would cause a collection and a liveness trace through statics while HMTasks were creating array instances. This would result in arrays being in unspecified and invalid states after they were populated (and placed into lists), which would then cause issues during this liveness traversal, since they have not yet been managed correctly.

It is unclear if this will perfectly resolve the issue, but this seems like some low hanging fruit to expand testing to ensure that RSL is no longer a potential source of liveness issues.